### PR TITLE
Use EDINET data directly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+venv/
+project/backend/.env
+project/frontend/node_modules/
+project/frontend/package-lock.json
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,97 @@
-# JOBhunting
+# Job Hunting App
+
+This repository provides a web application to help Japanese job seekers research companies.
+The backend downloads IR information from EDINET, extracts text from PDFs and asks OpenAI's GPT model to
+summarise company strengths, challenges and example motivation statements. The frontend is a simple
+React interface built with Vite.
+
+The backend exposes two endpoints. The company search uses fuzzy matching on
+EDINET so that similar corporate names can still return results. The condition
+search downloads the EDINET corporate list and filters by industry code and
+prefecture:
+
+- `POST /search_company` with `{ "company_name": "トヨタ自動車" }`
+- `POST /search_by_condition` with `{ "industry_code": "5200", "prefecture": "東京" }`
+
+The steps below walk you through setting up the environment, running the application locally and building
+for production. Commands assume Ubuntu 22.04.
+
+## Directory structure
+
+```
+project/
+├── backend/
+│   ├── main.py              # FastAPI application
+│   ├── requirements.txt     # Python dependencies
+│   ├── .env.example         # template for your OpenAI API key
+├── frontend/
+│   ├── src/                 # React source code
+│   │   ├── App.jsx
+│   │   ├── main.jsx
+│   │   └── index.css
+│   ├── public/
+│   │   └── index.html
+│   ├── package.json         # Node dependencies
+│   └── vite.config.js       # Vite configuration
+```
+
+## Prerequisites
+- **Python 3.10** or later
+- **Node.js 18** or later
+
+## Environment setup
+The commands below install the required tools and libraries. Lines starting with `$` are executed in the terminal.
+
+1. **Clone this repository**
+   ```bash
+   $ git clone <this repository url>
+   $ cd JOBhunting
+   ```
+2. **Install Python and create a virtual environment**
+   ```bash
+   $ sudo apt update
+   $ sudo apt install -y python3 python3-venv python3-pip
+   $ python3 -m venv venv
+   $ source venv/bin/activate
+   (venv) $ pip install -r project/backend/requirements.txt
+   (venv) $ cp project/backend/.env.example project/backend/.env
+   # open project/backend/.env and set your OpenAI API key
+   ```
+3. **Install Node.js and frontend dependencies**
+   ```bash
+   $ curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash -
+   $ sudo apt install -y nodejs
+   $ cd project/frontend
+   $ npm install
+   ```
+
+## Running the servers
+With the Python virtual environment activated in one terminal, start the FastAPI backend:
+```bash
+(venv) $ cd project/backend
+(venv) $ uvicorn main:app --reload --host 0.0.0.0 --port 8000
+```
+Leave that running. In a separate terminal start the React development server:
+```bash
+$ cd project/frontend
+$ npm run dev
+```
+After both servers start, open your browser to **http://localhost:5173** to try the app.
+
+To stop either server, return to its terminal and press `Ctrl+C`.
+
+## Building for production
+When you want to publish the frontend as static files, run:
+```bash
+$ cd project/frontend
+$ npm run build
+```
+The built files will be placed in `project/frontend/dist/`. You can preview them locally with:
+```bash
+$ npm run preview
+```
+The backend can be served in production using Uvicorn without `--reload` or via another ASGI server.
+
+## Notes
+- Do **not** commit your `.env` file. It contains your private OpenAI API key.
+- Access to EDINET may require a stable network connection. The search endpoint uses fuzzy matching but will still return a `404` error when nothing similar is found.

--- a/project/backend/.env.example
+++ b/project/backend/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=your_openai_api_key

--- a/project/backend/main.py
+++ b/project/backend/main.py
@@ -1,0 +1,170 @@
+import os
+import json
+import requests
+from difflib import SequenceMatcher
+import fitz
+import openai
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+from typing import List, Optional
+from dotenv import load_dotenv
+
+load_dotenv()
+
+openai.api_key = os.getenv("OPENAI_API_KEY")
+
+app = FastAPI()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+class CompanyRequest(BaseModel):
+    company_name: str
+
+class ConditionRequest(BaseModel):
+    industry_code: Optional[str] = None
+    prefecture: Optional[str] = None
+
+def fetch_edinet_pdf(company_name: str) -> bytes:
+    """Search EDINET for the latest document that roughly matches the company
+    name and return the PDF bytes."""
+
+    search_url = "https://disclosure.edinet-fsa.go.jp/api/v1/documents.json"
+    params = {"type": 2, "keyword": company_name, "date": "2024-01-01"}
+    resp = requests.get(search_url, params=params)
+    if resp.status_code != 200:
+        raise HTTPException(status_code=500, detail="Failed to query EDINET")
+    data = resp.json()
+    results = data.get("results") or []
+
+    if not results and len(company_name) > 2:
+        params["keyword"] = company_name[: len(company_name) // 2]
+        resp = requests.get(search_url, params=params)
+        if resp.status_code == 200:
+            data = resp.json()
+            results = data.get("results") or []
+
+    if not results:
+        raise HTTPException(status_code=404, detail="IR document not found")
+
+    best = None
+    best_score = 0.0
+    for r in results:
+        name = r.get("filerName", "")
+        score = SequenceMatcher(None, company_name, name).ratio()
+        if score > best_score:
+            best = r
+            best_score = score
+
+    if not best:
+        raise HTTPException(status_code=404, detail="IR document not found")
+
+    doc_id = best["docID"]
+    pdf_url = (
+        f"https://disclosure.edinet-fsa.go.jp/api/v1/documents/{doc_id}?type=1"
+    )
+    pdf_resp = requests.get(pdf_url)
+    pdf_resp.raise_for_status()
+    return pdf_resp.content
+
+
+def extract_text_from_pdf(pdf_bytes: bytes) -> str:
+    text = ""
+    with fitz.open(stream=pdf_bytes, filetype="pdf") as doc:
+        for page in doc:
+            text += page.get_text()
+    return text
+
+
+def analyze_ir(text: str) -> dict:
+    prompt = (
+        "以下のIR情報を読んで、会社の強み、課題、志望動機例を"
+        "JSON形式で日本語で出力してください。"
+    )
+    user_content = text[:4000]
+    messages = [
+        {"role": "system", "content": "あなたは優秀なキャリアアドバイザーです"},
+        {"role": "user", "content": prompt + "\n" + user_content},
+    ]
+    response = openai.ChatCompletion.create(model="gpt-3.5-turbo", messages=messages)
+    content = response.choices[0].message.content
+    return json.loads(content)
+
+
+CORPORATIONS_CACHE: List[dict] = []
+
+
+def fetch_corporations() -> List[dict]:
+    """Retrieve the EDINET corporate list and cache it."""
+    global CORPORATIONS_CACHE
+    if CORPORATIONS_CACHE:
+        return CORPORATIONS_CACHE
+    url = "https://disclosure.edinet-fsa.go.jp/api/v1/corporations.json"
+    resp = requests.get(url)
+    if resp.status_code != 200:
+        raise HTTPException(status_code=500, detail="Failed to fetch corporations")
+    data = resp.json()
+    CORPORATIONS_CACHE = data.get("results", [])
+    return CORPORATIONS_CACHE
+
+
+
+def analyze_company(name: str) -> dict:
+    try:
+        pdf_bytes = fetch_edinet_pdf(name)
+        text = extract_text_from_pdf(pdf_bytes)
+        analysis = analyze_ir(text)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail="Failed to analyze IR") from e
+    analysis["company"] = name
+    return analysis
+
+
+@app.post("/search_company")
+async def search_company(req: CompanyRequest):
+    """Analyze a single company's IR data."""
+    return analyze_company(req.company_name)
+
+
+@app.post("/search_by_condition")
+async def search_by_condition(cond: ConditionRequest):
+    """Return analyses for companies that match the given conditions."""
+    companies = fetch_corporations()
+
+    matched: List[dict] = []
+    for c in companies:
+        if cond.industry_code and cond.industry_code != c.get("industryCode"):
+            continue
+        if cond.prefecture and cond.prefecture not in c.get("prefectureName", ""):
+            continue
+        matched.append(c)
+
+    if not matched:
+        raise HTTPException(status_code=404, detail="No companies found")
+
+    results = []
+    for c in matched[:5]:
+        name = c.get("filerName")
+        try:
+            analysis = analyze_company(name)
+            analysis["edinetCode"] = c.get("edinetCode")
+            results.append(analysis)
+        except HTTPException:
+            continue
+
+    if not results:
+        raise HTTPException(status_code=500, detail="Failed to analyze IR")
+
+    return {"results": results}
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/project/backend/requirements.txt
+++ b/project/backend/requirements.txt
@@ -1,0 +1,6 @@
+fastapi
+uvicorn
+requests
+python-dotenv
+PyMuPDF
+openai

--- a/project/frontend/package.json
+++ b/project/frontend/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "job-hunting-frontend",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^4.3.0"
+  }
+}

--- a/project/frontend/public/index.html
+++ b/project/frontend/public/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Job Hunting App</title>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/main.jsx"></script>
+</body>
+</html>

--- a/project/frontend/src/App.jsx
+++ b/project/frontend/src/App.jsx
@@ -1,0 +1,106 @@
+import React, { useState } from 'react'
+
+function App() {
+  const [companyName, setCompanyName] = useState('')
+  const [result, setResult] = useState(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [condition, setCondition] = useState({
+    industry: '',
+    location: '',
+    salary_min: '',
+    culture: ''
+  })
+
+  const searchCompany = async () => {
+    setLoading(true)
+    setError('')
+    try {
+      const res = await fetch('http://localhost:8000/search_company', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ company_name: companyName })
+      })
+      if (!res.ok) throw new Error('検索に失敗しました')
+      const data = await res.json()
+      setResult(data)
+    } catch (e) {
+      setError(e.message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const searchByCondition = async () => {
+    setLoading(true)
+    setError('')
+    try {
+      const res = await fetch('http://localhost:8000/search_by_condition', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          industry: condition.industry,
+          location: condition.location,
+          salary_min: Number(condition.salary_min),
+          culture: condition.culture
+        })
+      })
+      if (!res.ok) throw new Error('検索に失敗しました')
+      const data = await res.json()
+      setResult(data)
+    } catch (e) {
+      setError(e.message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div style={{ padding: '1rem' }}>
+      <h1>就活支援アプリ</h1>
+      <div style={{ marginBottom: '1rem' }}>
+        <h2>企業名で検索</h2>
+        <input value={companyName} onChange={(e) => setCompanyName(e.target.value)} />
+        <button onClick={searchCompany}>検索</button>
+      </div>
+      <div style={{ marginBottom: '1rem' }}>
+        <h2>条件で検索</h2>
+        <input placeholder="業界" value={condition.industry} onChange={(e) => setCondition({ ...condition, industry: e.target.value })} />
+        <input placeholder="勤務地" value={condition.location} onChange={(e) => setCondition({ ...condition, location: e.target.value })} />
+        <input placeholder="最低年収" value={condition.salary_min} onChange={(e) => setCondition({ ...condition, salary_min: e.target.value })} />
+        <input placeholder="社風" value={condition.culture} onChange={(e) => setCondition({ ...condition, culture: e.target.value })} />
+        <button onClick={searchByCondition}>検索</button>
+      </div>
+      {loading && <p>検索中...</p>}
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+      {result && (
+        <div>
+          <h2>強み</h2>
+          {Array.isArray(result.strengths) ? (
+            <ul>
+              {result.strengths.map((s, i) => (
+                <li key={i}>{s}</li>
+              ))}
+            </ul>
+          ) : (
+            <p>{result.strengths}</p>
+          )}
+          <h2>課題</h2>
+          {Array.isArray(result.challenges) ? (
+            <ul>
+              {result.challenges.map((c, i) => (
+                <li key={i}>{c}</li>
+              ))}
+            </ul>
+          ) : (
+            <p>{result.challenges}</p>
+          )}
+          <h2>志望動機例</h2>
+          <p>{result.motivation}</p>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default App

--- a/project/frontend/src/index.css
+++ b/project/frontend/src/index.css
@@ -1,0 +1,1 @@
+body { font-family: sans-serif; }

--- a/project/frontend/src/main.jsx
+++ b/project/frontend/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import "./index.css"
+import ReactDOM from 'react-dom/client'
+import App from './App'
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/project/frontend/vite.config.js
+++ b/project/frontend/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173
+  }
+})


### PR DESCRIPTION
## Summary
- remove local demo datasets
- load corporate list from EDINET and filter by industry code & prefecture
- update README usage instructions
- ignore `package-lock.json`

## Testing
- `python3 -m compileall project/backend`
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_6870e68e545c8323ad9edf1bc3054b9a